### PR TITLE
Multiple Instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,8 @@ MAINTAINER Pomadchin Grigory, daunnc@gmail.com
 ENV ACCUMULO_VERSION 1.7.2
 ENV ACCUMULO_HOME /opt/accumulo
 ENV ACCUMULO_CONF_DIR $ACCUMULO_HOME/conf
-
 ENV ZOOKEEPER_HOME /usr/lib/zookeeper
-
-ENV PATH $PATH:$ACCUMULO_HOME/bin:$GEOMESA_HOME/bin
+ENV PATH=$PATH:$ACCUMULO_HOME/bin
 
 # Accumulo and Zookeeper client
 RUN set -x \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ ENV PATH=$PATH:$ACCUMULO_HOME/bin
 
 # Accumulo and Zookeeper client
 RUN set -x \
-  && curl http://archive.apache.org/dist/bigtop/bigtop-1.1.0/repos/centos7/bigtop.repo > /etc/yum.repos.d/bigtop.repo \
-  && yum -y install zookeeper \
   && mkdir -p ${ACCUMULO_HOME} ${ACCUMULO_CONF_DIR} \
   && curl -sS -# http://apache.mirrors.pair.com/accumulo/${ACCUMULO_VERSION}/accumulo-${ACCUMULO_VERSION}-bin.tar.gz \
   | tar -xz -C ${ACCUMULO_HOME} --strip-components=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN set -x \
   && cp ${ACCUMULO_HOME}/conf/examples/3GB/standalone/* ${ACCUMULO_CONF_DIR}/ \
   && yum install -y make gcc-c++ \
   && bash -c "${ACCUMULO_HOME}/bin/build_native_library.sh" \
-  && yum remove -y make gcc-c++ \
-  && yum -y autoremove
+  && yum -y autoremove gcc-c++
   # TODO: Clean up after build_native_library
 
 WORKDIR "${ACCUMULO_HOME}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN set -x \
   && mkdir -p ${ACCUMULO_HOME} ${ACCUMULO_CONF_DIR} \
   && curl -sS -# http://apache.mirrors.pair.com/accumulo/${ACCUMULO_VERSION}/accumulo-${ACCUMULO_VERSION}-bin.tar.gz \
   | tar -xz -C ${ACCUMULO_HOME} --strip-components=1 \
-  && cp ${ACCUMULO_HOME}/conf/examples/3GB/standalone/* ${ACCUMULO_CONF_DIR}/ \
   && yum install -y make gcc-c++ \
   && bash -c "${ACCUMULO_HOME}/bin/build_native_library.sh" \
   && yum -y autoremove gcc-c++

--- a/emr/bootstrap-geodocker-accumulo.sh
+++ b/emr/bootstrap-geodocker-accumulo.sh
@@ -63,11 +63,11 @@ fi
 
 YARN_RM=$(xmllint --xpath "//property[name='yarn.resourcemanager.hostname']/value/text()"  /etc/hadoop/conf/yarn-site.xml)
 DOCKER_ENV="-e USER=hadoop \
--e HADOOP_MASTER_ADDRESS=$YARN_RM \
 -e ZOOKEEPERS=$YARN_RM \
 -e ACCUMULO_SECRET=$ACCUMULO_SECRET \
 -e ACCUMULO_PASSWORD=$ACCUMULO_PASSWORD \
--e INSTANCE_NAME=$INSTANCE_NAME"
+-e INSTANCE_NAME=$INSTANCE_NAME \
+-v /etc/hadoop/conf:/etc/hadoop/conf"
 
 DOCKER_OPT="-d --net=host --restart=always"
 if is_master ; then

--- a/fs/opt/accumulo/conf/accumulo-site.xml.template
+++ b/fs/opt/accumulo/conf/accumulo-site.xml.template
@@ -20,16 +20,16 @@
 <configuration>
   <property>
     <name>instance.volumes</name>
-    <value>hdfs://{HADOOP_MASTER_ADDRESS}/accumulo</value>
+    <value>${INSTANCE_VOLUME}</value>
   </property>
   <property>
     <name>instance.zookeeper.host</name>
-    <value>{ZOOKEEPERS}</value>
+    <value>${ZOOKEEPERS}</value>
     <description>comma separated list of zookeeper servers</description>
   </property>
   <property>
     <name>general.vfs.classpaths</name>
-    <value>hdfs://{HADOOP_MASTER_ADDRESS}/accumulo-classpath/[^.].*.jar</value>
+    <value>${INSTANCE_VOLUME}-classpath/[^.].*.jar</value>
     <description>Configuration for a system level vfs classloader. Accumulo jars can be configured here and loaded out of HDFS.</description>
   </property>
   <!-- <property>
@@ -46,7 +46,7 @@
     <name>general.dynamic.classpaths</name>
     <value>
       $ACCUMULO_HOME/lib/ext/[^.].*.jar,
-      hdfs://{HADOOP_MASTER_ADDRESS}/accumulo-classpath/[^.].*.jar
+      ${INSTANCE_VOLUME}-classpath/[^.].*.jar
     </value>
     <description>Classpaths that accumulo checks for updates and class files.</description>
   </property>
@@ -60,7 +60,7 @@
   </property>
   <property>
     <name>instance.secret</name>
-    <value>{ACCUMULO_SECRET}</value>
+    <value>${ACCUMULO_SECRET}</value>
     <description>A secret unique to a given instance that all servers must know in order to communicate with one another.
       Change it before initialization. To
       change it later use ./bin/accumulo org.apache.accumulo.server.util.ChangeSecret --old [oldpasswd] --new [newpasswd],
@@ -83,40 +83,6 @@
     <name>tserver.cache.index.size</name>
     <value>128M</value>
   </property>
-  <!-- <property>
-    <name>trace.token.property.password</name>
-    <value>{ACCUMULO_TRACE_PASSWORD}</value>
-  </property> -->
-  <!-- Kerberos requirements --><!--
-  <property>
-    <name>instance.rpc.sasl.enabled</name>
-    <value>true</value>
-  </property>
-  <property>
-    <name>general.kerberos.keytab</name>
-    <value>${keytab}</value>
-  </property>
-  <property>
-    <name>general.kerberos.principal</name>
-    <value>${principal}</value>
-  </property>
-  <property>
-    <name>trace.token.type</name>
-    <value>org.apache.accumulo.core.client.security.tokens.KerberosToken</value>
-  </property>
-  <property>
-    <name>instance.security.authenticator</name>
-    <value>org.apache.accumulo.server.security.handler.KerberosAuthenticator</value>
-  </property>
-  <property>
-    <name>instance.security.authorizor</name>
-    <value>org.apache.accumulo.server.security.handler.KerberosAuthorizor</value>
-  </property>
-  <property>
-    <name>instance.security.permissionHandler</name>
-    <value>org.apache.accumulo.server.security.handler.KerberosPermissionHandler</value>
-  </property>
-  --><!-- End Kerberos requirements -->
   <property>
     <name>trace.user</name>
     <value>root</value>
@@ -143,14 +109,6 @@
       $ZOOKEEPER_HOME/zookeeper[^.].*.jar,
       <!-- Common Hadoop requirements -->
       $HADOOP_CONF_DIR,
-      <!-- Hadoop 2 requirements -->
-      $HADOOP_PREFIX/share/hadoop/common/[^.].*.jar,
-      $HADOOP_PREFIX/share/hadoop/common/lib/(?!slf4j)[^.].*.jar,
-      $HADOOP_PREFIX/share/hadoop/hdfs/[^.].*.jar,
-      $HADOOP_PREFIX/share/hadoop/mapreduce/[^.].*.jar,
-      $HADOOP_PREFIX/share/hadoop/yarn/[^.].*.jar,
-      $HADOOP_PREFIX/share/hadoop/yarn/lib/jersey.*.jar,
-      <!-- End Hadoop 2 requirements -->
       <!-- HDP 2.0 requirements -->
       /usr/lib/hadoop/[^.].*.jar,
       /usr/lib/hadoop/lib/[^.].*.jar,
@@ -159,15 +117,6 @@
       /usr/lib/hadoop-yarn/[^.].*.jar,
       /usr/lib/hadoop-yarn/lib/jersey.*.jar,
       <!-- End HDP 2.0 requirements -->
-      <!-- HDP 2.2 requirements --><!--
-      /usr/hdp/current/hadoop-client/[^.].*.jar,
-      /usr/hdp/current/hadoop-client/lib/(?!slf4j)[^.].*.jar,
-      /usr/hdp/current/hadoop-hdfs-client/[^.].*.jar,
-      /usr/hdp/current/hadoop-mapreduce-client/[^.].*.jar,
-      /usr/hdp/current/hadoop-yarn-client/[^.].*.jar,
-      /usr/hdp/current/hadoop-yarn-client/lib/jersey.*.jar,
-      /usr/hdp/current/hive-client/lib/hive-accumulo-handler.jar
-      --><!-- End HDP 2.2 requirements -->
     </value>
     <description>Classpaths that accumulo checks for updates and class files.</description>
   </property>


### PR DESCRIPTION
This PR takes advantage of template configs from https://github.com/geodocker/geodocker-hdfs/pull/2. Spacial care is taken to re-read the  config files in case they have been volume mounted.

Also we add `INSTANCE_VOLUME` env var to the template. By default it includes the `INSTANCE_NAME` to allow hosting multiple instances on shared HDFS/Zookeper.
