### PR TITLE
Zookeeper Instance Checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ services:
 - docker
 env:
   global:
-  - DOCKER_VERSION=1.11.2-0~trusty
-  - DOCKER_COMPOSE_VERSION=1.8.0-rc2
+  - DOCKER_VERSION=1.12.0-0~trusty
+  - DOCKER_COMPOSE_VERSION=1.8.0
   - ORG=${TRAVIS_REPO_SLUG%/*}
   - REPO=${TRAVIS_REPO_SLUG##*-}
   - TAG=${TRAVIS_TAG:-${TRAVIS_COMMIT:0:7}}


### PR DESCRIPTION
Instead of relying on `accumulo info` or HDFS state we check for existence of zookeeper key to see if an instance has been initialized. 
