### PR TITLE
Download Tarball To Host, Provide Post-Initialization Hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+accumulo-1.?.?-bin.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
 FROM quay.io/geodocker/hdfs:latest
 
-MAINTAINER Pomadchin Grigory, daunnc@gmail.com
+MAINTAINER Pomadchin Grigory <daunnc@gmail.com>
 
-ENV ACCUMULO_VERSION 1.7.2
+ARG ACCUMULO_VERSION
+ENV ACCUMULO_VERSION ${ACCUMULO_VERSION}
 ENV ACCUMULO_HOME /opt/accumulo
 ENV ACCUMULO_CONF_DIR $ACCUMULO_HOME/conf
 ENV ZOOKEEPER_HOME /usr/lib/zookeeper
 ENV PATH=$PATH:$ACCUMULO_HOME/bin
 
+ADD accumulo-${ACCUMULO_VERSION}-bin.tar.gz /opt
+
 # Accumulo and Zookeeper client
 RUN set -x \
-  && mkdir -p ${ACCUMULO_HOME} ${ACCUMULO_CONF_DIR} \
-  && curl -sS -# http://apache.mirrors.pair.com/accumulo/${ACCUMULO_VERSION}/accumulo-${ACCUMULO_VERSION}-bin.tar.gz \
-  | tar -xz -C ${ACCUMULO_HOME} --strip-components=1 \
+  && mv /opt/accumulo-${ACCUMULO_VERSION} ${ACCUMULO_HOME} \
   && yum install -y make gcc-c++ \
   && bash -c "${ACCUMULO_HOME}/bin/build_native_library.sh" \
   && yum -y autoremove gcc-c++

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,15 @@ BASE := $(subst -, ,$(notdir ${CURDIR}))
 ORG  := $(word 1, ${BASE})
 REPO := $(word 2, ${BASE})
 IMG  := quay.io/${ORG}/${REPO}
+ACCUMULO_VERSION := 1.7.2
 
-build:
-	docker build -t ${IMG}:latest	.
+build: accumulo-${ACCUMULO_VERSION}-bin.tar.gz
+	docker build \
+		--build-arg ACCUMULO_VERSION=${ACCUMULO_VERSION} \
+		-t ${IMG}:latest .
+
+accumulo-${ACCUMULO_VERSION}-bin.tar.gz:
+	curl -L -C - -O "http://apache.mirrors.pair.com/accumulo/${ACCUMULO_VERSION}/accumulo-${ACCUMULO_VERSION}-bin.tar.gz"
 
 publish: build
 	docker push ${IMG}:latest
@@ -17,3 +23,10 @@ test: build
 		&& wait_until_accumulo_is_available \
 		&& accumulo shell -p GisPwd -e 'info'"
 	docker-compose down
+
+clean:
+
+cleaner: clean
+
+cleanest: cleaner
+	rm -f accumulo-${ACCUMULO_VERSION}-bin.tar.gz

--- a/fs/sbin/entrypoint.sh
+++ b/fs/sbin/entrypoint.sh
@@ -39,6 +39,11 @@ else
           echo "Initilizing accumulo instance $INSTANCE_VOLUME ..."
           runuser -p -u $USER hdfs -- dfs -mkdir -p ${INSTANCE_VOLUME}-classpath
           runuser -p -u $USER accumulo -- init --instance-name ${INSTANCE_NAME} --password ${ACCUMULO_PASSWORD}
+
+	  if [[ -n ${POSTINIT:-} ]]; then
+	     echo "Post-initializing accumulo instance $INSTANCE_VOLUME ..."
+	     (setsid $POSTINIT &> /tmp/${INSTANCE_NAME}-postinit.log &)
+	  fi
         fi
       fi
 


### PR DESCRIPTION
The build process has been changed so that the Accumulo tarball is downloaded to the host rather than in the container.  This allows the tarball to be kept, which tightens the feedback loop when working on the image.

This pull request is also required to make my [consistent iterator registration branch](https://github.com/jamesmcclain/geodocker-accumulo-geomesa/tree/fix/make-registration-consistent) work.  That branch makes registration of the iterators succeed more consistently by removing a race between `accumulo init` and the series of `accumulo shell` commands needed to register the iterators.

Note that geodocker/geodocker-accumulo-geomesa#11 **does not** depend on this pull request.
