### PR TITLE
Set container swappiness to 0 on EMR

### DIFF
--- a/emr/bootstrap-geodocker-accumulo.sh
+++ b/emr/bootstrap-geodocker-accumulo.sh
@@ -69,7 +69,7 @@ DOCKER_ENV="-e USER=hadoop \
 -e INSTANCE_NAME=$INSTANCE_NAME \
 -v /etc/hadoop/conf:/etc/hadoop/conf"
 
-DOCKER_OPT="-d --net=host --restart=always"
+DOCKER_OPT="-d --net=host --restart=always --memory-swappiness=0"
 if is_master ; then
     docker run $DOCKER_OPT --name=accumulo-master $DOCKER_ENV $IMAGE master --auto-init
     docker run $DOCKER_OPT --name=accumulo-monitor $DOCKER_ENV $IMAGE monitor


### PR DESCRIPTION
> The linux kernel will swap out memory of running programs to increase the size of the disk buffers. This tendency to swap out is controlled by a kernel setting called "swappiness." This behavior does not work well for large java servers. When a java process runs a garbage collection, it touches lots of pages forcing all swapped out pages back into memory. It is suggested that swappiness be set to zero.

-- https://archive.cloudera.com/accumulo-c5/cdh/5/accumulo/administration.html
