### PR TITLE
Volume mount EMR hdfs script for eval

### DIFF
--- a/emr/bootstrap-geodocker-accumulo.sh
+++ b/emr/bootstrap-geodocker-accumulo.sh
@@ -67,7 +67,8 @@ DOCKER_ENV="-e USER=hadoop \
 -e ACCUMULO_SECRET=$ACCUMULO_SECRET \
 -e ACCUMULO_PASSWORD=$ACCUMULO_PASSWORD \
 -e INSTANCE_NAME=$INSTANCE_NAME \
--v /etc/hadoop/conf:/etc/hadoop/conf"
+-v /etc/hadoop/conf:/etc/hadoop/conf \
+-v /usr/lib/hadoop-hdfs/bin:/usr/lib/hadoop-hdfs/bin"
 
 DOCKER_OPT="-d --net=host --restart=always"
 if is_master ; then


### PR DESCRIPTION
This resolves the issue that suddenly started happening. Ultimately it was traced to `hdfs` command on EMR doing `eval exec java` instead of `exac java`. Not clear when this change in EMR environment took place because all versions are pinned.
